### PR TITLE
Remove unneeded dependency on shared-resources

### DIFF
--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -2,7 +2,6 @@
 <package xmlns="http://expath.org/ns/pkg" name="http://existsolutions.com/apps/tei-publisher-lib" abbrev="tei-publisher-lib" version="2.8.11" spec="1.0">
     <title>TEI Publisher: Processing Model Libraries</title>
     <dependency processor="http://exist-db.org" semver-min="3.6.0" />
-    <dependency package="http://exist-db.org/apps/shared" />
     <xquery>
         <namespace>http://www.tei-c.org/tei-simple/xquery/functions</namespace>
         <file>html-functions.xql</file>


### PR DESCRIPTION
In my searching there is no actual dependency on [shared-resources](https://github.com/eXist-db/shared-resources). There are no references to the templating, dbutil, apputil, or site modules.