### PR TITLE
Support for web annotations

### DIFF
--- a/content/html-functions.xql
+++ b/content/html-functions.xql
@@ -125,6 +125,10 @@ declare function pmf:section($config as map(*), $node as node(), $class as xs:st
     <section class="{$class}">{pmf:apply-children($config, $node, $content)}</section>
 };
 
+declare function pmf:pass-through($config as map(*), $node as node(), $class as xs:string+, $content) {
+    pmf:apply-children($config, $node, $content)
+};
+
 declare function pmf:anchor($config as map(*), $node as node(), $class as xs:string+, $content, $id as item()*) {
     <span id="{$id}"/>
 };

--- a/content/model.xql
+++ b/content/model.xql
@@ -291,11 +291,14 @@ if ($trackIds) then
                 $node
             case element() return
                 if ($node/@class = ("footnote")) then
-                    element {{ node-name($node) }} {{
-                        $node/@*,
-                        $node/*[@class="fn-number"],
-                        model:map($node/*[@class="fn-content"], $context, $trackIds)
-                    }}
+                    if (local-name($node) = 'pb-popover') then
+                        ()
+                    else
+                        element {{ node-name($node) }} {{
+                            $node/@*,
+                            $node/*[@class="fn-number"],
+                            model:map($node/*[@class="fn-content"], $context, $trackIds)
+                        }}
                 else
                     element {{ node-name($node) }} {{
                         attribute data-tei {{ util:node-id($context) }},

--- a/content/model.xql
+++ b/content/model.xql
@@ -262,15 +262,13 @@ return
                 <body>
 let $classRegex := analyze-string($html/@class, '\s?annotation-([^\s]+)\s?')
 return
-    if ($classRegex//fn:match) then
+    if ($classRegex//fn:match) then (
+        attribute data-type {{ ($classRegex//fn:group)[1]/string() }},
         attribute data-annotation {{
-            map {{ 
-                "type": ($classRegex//fn:group)[1]/string(),
-                "properties": map:merge($context/@* ! map:entry(node-name(.), ./string()))
-            }}
+            map:merge($context/@* ! map:entry(node-name(.), ./string()))
             => serialize(map {{ "method": "json" }})
         }}
-    else
+    ) else
         ()
                 </body>
             </function>

--- a/content/model.xql
+++ b/content/model.xql
@@ -286,12 +286,19 @@ if ($trackIds) then
             case document-node() | comment() | processing-instruction() return 
                 $node
             case element() return
-                element {{ node-name($node) }} {{
-                    attribute data-tei {{ util:node-id($context) }},
-                    $node/@*,
-                    model:process-annotation($node, $context),
-                    $node/node()
-                }}
+                if ($node/@class = ("footnote")) then
+                    element {{ node-name($node) }} {{
+                        $node/@*,
+                        $node/*[@class="fn-number"],
+                        model:map($node/*[@class="fn-content"], $context, $trackIds)
+                    }}
+                else
+                    element {{ node-name($node) }} {{
+                        attribute data-tei {{ util:node-id($context) }},
+                        $node/@*,
+                        model:process-annotation($node, $context),
+                        $node/node()
+                    }}
             default return
                 &lt;pb-anchor data-tei="{{ util:node-id($context) }}"&gt;{{$node}}&lt;/pb-anchor&gt;
 else

--- a/content/model.xql
+++ b/content/model.xql
@@ -247,6 +247,25 @@ return
     else
         $elem</body>
             </function>
+            <function name="model:map">
+                <param>$html</param>
+                <param>$context as node()</param>
+                <body>
+for $node in $html
+return
+    typeswitch ($node)
+            case document-node() | comment() | processing-instruction() return
+                $node
+            case element() return
+                element {{ node-name($node) }} {{
+                    attribute data-tei {{ util:node-id($context) }},
+                    $node/@*,
+                    $node/node()
+                }}
+            default return
+                &lt;pb-anchor data-tei="{{ util:node-id($context) }}"&gt;{{$node}}&lt;/pb-anchor&gt;
+                </body>
+            </function>
             </module>
         </xquery>
     return
@@ -442,7 +461,8 @@ declare %private function pm:model($ident as xs:string, $model as element(tei:mo
                             pm:map-parameters($signature, $params, $ident, $modules, $output, exists($model/pb:template)),
                             pm:optional-parameters($signature, $params)
                         }
-                    </function-call>
+                    </function-call>,
+                    "=> model:map($node)"
                 } catch pm:not-found {
                     <comment>Failed to map function for behavior {$behaviour/string()}. {$err:description}</comment>,
                     <comment>{serialize($model)}</comment>,

--- a/content/model.xql
+++ b/content/model.xql
@@ -35,6 +35,10 @@ declare variable $pm:ERR_TOO_MANY_MODELS := xs:QName("pm:too-many-models");
 declare variable $pm:MULTIPLE_FUNCTIONS_FOUND := xs:QName("pm:multiple-functions");
 declare variable $pm:NOT_FOUND := xs:QName("pm:not-found");
 
+declare function pm:parse($odd as element(), $modules as array(*), $output as xs:string*) as map(*) {
+    pm:parse($odd, $modules, $output, false())
+};
+
 (:~
  : Parse the given ODD and generate an XQuery transformation module.
  :
@@ -44,7 +48,7 @@ declare variable $pm:NOT_FOUND := xs:QName("pm:not-found");
  : will be used.
  : @param output the output method to use ("web" by default)
  :)
-declare function pm:parse($odd as element(), $modules as array(*), $output as xs:string*) as map(*) {
+declare function pm:parse($odd as element(), $modules as array(*), $output as xs:string*, $trackIds as xs:boolean?) as map(*) {
     let $output := if (exists($output)) then $output else "web"
     let $oddPath := ($odd/@source/string(), document-uri(root($odd)))[1]
     let $name := replace($oddPath, "^.*?([^/\.]+)\.[^\.]+$", "$1")
@@ -125,7 +129,7 @@ return (
                                                         <typeswitch op=".">
                                                             {
                                                                 for $spec in $odd//tei:elementSpec[not(@ident=('text()', '*'))][.//tei:model]
-                                                                let $case := pm:elementSpec($spec, $moduleDesc, $output)
+                                                                let $case := pm:elementSpec($spec, $moduleDesc, $output, $trackIds)
                                                                 return
                                                                     if (exists($case)) then (
                                                                         if ($spec/tei:desc) then
@@ -156,7 +160,8 @@ return (
                                                                                 "-element",
                                                                                 pm:get-model-elements($defaultSpec, $output),
                                                                                 $moduleDesc,
-                                                                                $output
+                                                                                $output,
+                                                                                $trackIds
                                                                             )
                                                                         }
                                                                         </case>
@@ -181,7 +186,8 @@ return (
                                                                                 "-text",
                                                                                 pm:get-model-elements($defaultSpec, $output),
                                                                                 $moduleDesc,
-                                                                                $output
+                                                                                $output,
+                                                                                $trackIds
                                                                             )
                                                                         }
                                                                         </case>
@@ -328,7 +334,7 @@ declare %private function pm:finish-modules($modules as array(*)) {
 };
 
 
-declare %private function pm:elementSpec($spec as element(tei:elementSpec), $modules as array(*), $output as xs:string+) {
+declare %private function pm:elementSpec($spec as element(tei:elementSpec), $modules as array(*), $output as xs:string+, $trackIds as xs:boolean?) {
     let $models := pm:get-model-elements($spec, $output)
     return
         if ($models) then
@@ -336,20 +342,21 @@ declare %private function pm:elementSpec($spec as element(tei:elementSpec), $mod
                 $spec/@ident,
                 $models,
                 $modules,
-                $output
+                $output,
+                $trackIds
             )
         else
             ()
 };
 
 declare %private function pm:process-models($ident as xs:string, $models as element()+, $modules as array(*),
-    $output as xs:string+) {
+    $output as xs:string+, $trackIds as xs:boolean?) {
     if ($models[1][not(@predicate)]) then
-        pm:model-or-sequence($ident, $models[1], $modules, $output)
+        pm:model-or-sequence($ident, $models[1], $modules, $output, $trackIds)
     else if ($models[@predicate]) then
         fold-right($models[@predicate], (), function($cond, $zero) {
             <if test="{$cond/@predicate}">
-                <then>{pm:model-or-sequence($ident, $cond, $modules, $output)}</then>
+                <then>{pm:model-or-sequence($ident, $cond, $modules, $output, $trackIds)}</then>
                 {
                     if ($zero) then
                         <else>{$zero}</else>
@@ -360,12 +367,12 @@ declare %private function pm:process-models($ident as xs:string, $models as elem
                                 if (count($models[not(@predicate)]) > 1 and not($models/parent::tei:modelSequence)) then (
                                     <comment>More than one model without predicate found for ident {$ident}.
                                     Choosing first one.</comment>,
-                                    pm:model-or-sequence($ident, $models[not(@predicate)][1], $modules, $output)
+                                    pm:model-or-sequence($ident, $models[not(@predicate)][1], $modules, $output, $trackIds)
 (:                                    error($pm:ERR_TOO_MANY_MODELS,:)
 (:                                        "More than one model without predicate found " ||:)
 (:                                        "outside modelSequence for ident '" || $ident || "'"):)
                                 ) else
-                                    pm:model-or-sequence($ident, $models[not(@predicate)], $modules, $output)
+                                    pm:model-or-sequence($ident, $models[not(@predicate)], $modules, $output, $trackIds)
                             else
                                 <function-call name="$config?apply">
                                     <param>$config</param>
@@ -379,33 +386,34 @@ declare %private function pm:process-models($ident as xs:string, $models as elem
     else if (count($models) > 1 and not($models/parent::tei:modelSequence)) then (
         <comment>More than one model without predicate found for ident {$ident}.
         Choosing first one.</comment>,
-        pm:model-or-sequence($ident, $models[1], $modules, $output)
+        pm:model-or-sequence($ident, $models[1], $modules, $output, $trackIds)
     ) else
-        $models ! pm:model-or-sequence($ident, ., $modules, $output)
+        $models ! pm:model-or-sequence($ident, ., $modules, $output, $trackIds)
 };
 
 declare %private function pm:model-or-sequence($ident as xs:string, $models as element()+,
-    $modules as array(*), $output as xs:string+) {
+    $modules as array(*), $output as xs:string+, $trackIds as xs:boolean?) {
     for $model in $models
     return
         typeswitch($model)
             case element(tei:model) return
-                pm:model($ident, $model, $modules, $output)
+                pm:model($ident, $model, $modules, $output, $trackIds)
             case element(tei:modelSequence) return
-                pm:modelSequence($ident, $model, $modules, $output)
+                pm:modelSequence($ident, $model, $modules, $output, $trackIds)
             case element(tei:modelGrp) return
-                pm:process-models($ident, $model/*, $modules, $output)
+                pm:process-models($ident, $model/*, $modules, $output, $trackIds)
             default return
                 ()
 };
 
-declare %private function pm:model($ident as xs:string, $model as element(tei:model), $modules as array(*), $output as xs:string+) {
+declare %private function pm:model($ident as xs:string, $model as element(tei:model), $modules as array(*), 
+    $output as xs:string+, $trackIds as xs:boolean?) {
     let $behaviour := $model/@behaviour
     let $task := normalize-space($model/@behaviour)
     let $nested := pm:get-model-elements($model, $output)
     let $content :=
         if ($nested) then
-            pm:process-models($ident, $nested, $modules, $output)
+            pm:process-models($ident, $nested, $modules, $output, $trackIds)
         else
             "."
     let $params := $model/tei:param
@@ -458,11 +466,11 @@ declare %private function pm:model($ident as xs:string, $model as element(tei:mo
                         }
                         </param>
                         {
-                            pm:map-parameters($signature, $params, $ident, $modules, $output, exists($model/pb:template)),
+                            pm:map-parameters($signature, $params, $ident, $modules, $output, exists($model/pb:template), $trackIds),
                             pm:optional-parameters($signature, $params)
                         }
                     </function-call>,
-                    "=> model:map($node)"
+                    if ($trackIds) then "=> model:map($node)" else ()
                 } catch pm:not-found {
                     <comment>Failed to map function for behavior {$behaviour/string()}. {$err:description}</comment>,
                     <comment>{serialize($model)}</comment>,
@@ -478,7 +486,7 @@ declare %private function pm:model($ident as xs:string, $model as element(tei:mo
 };
 
 declare %private function pm:modelSequence($ident as xs:string, $seq as element(tei:modelSequence),
-    $modules as array(*), $output as xs:string+) {
+    $modules as array(*), $output as xs:string+, $trackIds as xs:boolean?) {
     <sequence>
     {
         for $model in $seq/(tei:model|tei:modelSequence|tei:modelGrp)[not(@output)] |
@@ -488,11 +496,11 @@ declare %private function pm:modelSequence($ident as xs:string, $seq as element(
             {
                 if ($model/@predicate) then
                     <if test="{$model/@predicate}">
-                        <then>{pm:model-or-sequence($ident, $model, $modules, $output)}</then>
+                        <then>{pm:model-or-sequence($ident, $model, $modules, $output, $trackIds)}</then>
                         <else>()</else>
                     </if>
                 else
-                    pm:model-or-sequence($ident, $model, $modules, $output)
+                    pm:model-or-sequence($ident, $model, $modules, $output, $trackIds)
             }
             </item>
     }
@@ -584,7 +592,7 @@ declare %private function pm:behaviour-function-meta($behave as element(pb:behav
 };
 
 declare function pm:map-parameters($signature as element(function), $params as element(tei:param)+,  $ident as xs:string, $modules as array(*),
-    $output as xs:string+, $hasTemplate as xs:boolean?) {
+    $output as xs:string+, $hasTemplate as xs:boolean?, $trackIds as xs:boolean?) {
     for $arg in subsequence($signature/argument, 4)
     let $mapped := $params[@name = $arg/@var]
     return
@@ -592,7 +600,7 @@ declare function pm:map-parameters($signature as element(function), $params as e
             let $nested := pm:get-model-elements($mapped, $output)
             return
                 if ($nested) then
-                    <param>{ pm:process-models($ident, $nested, $modules, $output) }</param>
+                    <param>{ pm:process-models($ident, $nested, $modules, $output, $trackIds) }</param>
                 else if ($hasTemplate and $arg/@var = 'content') then
                     <param>$content</param>
                 else

--- a/content/model.xql
+++ b/content/model.xql
@@ -263,11 +263,17 @@ return
 let $classRegex := analyze-string($html/@class, '\s?annotation-([^\s]+)\s?')
 return
     if ($classRegex//fn:match) then (
-        attribute data-type {{ ($classRegex//fn:group)[1]/string() }},
-        attribute data-annotation {{
-            map:merge($context/@* ! map:entry(node-name(.), ./string()))
-            => serialize(map {{ "method": "json" }})
-        }}
+        if ($html/@data-type) then
+            ()
+        else
+            attribute data-type {{ ($classRegex//fn:group)[1]/string() }},
+        if ($html/@data-annotation) then
+            ()
+        else
+            attribute data-annotation {{
+                map:merge($context/@* ! map:entry(node-name(.), ./string()))
+                => serialize(map {{ "method": "json" }})
+            }}
     ) else
         ()
                 </body>

--- a/content/util.xql
+++ b/content/util.xql
@@ -115,9 +115,22 @@ declare function pmu:process($oddPath as xs:string, $xml as node()*, $output-roo
         util:eval(xs:anyURI($uri), false(), (xs:QName("xml"), $xml, xs:QName("parameters"), $parameters))
 };
 
-
 declare function pmu:process-odd($odd as document-node(), $output-root as xs:string,
     $mode as xs:string, $relPath as xs:string, $config as element(modules)?) as map(*) {
+};
+
+(:~
+ : Compile the given ODD into an XQuery module.
+ :
+ : @param $odd the ODD document to compile
+ : @param $output-root collection URI into which to write generated files
+ : @param $mode the output mode (web, print etc.) for which to generate files
+ : @param $relPath path relative to the generated code for loading CSS etc.
+ : @param $trackIds if true, elements generated from a model of the ODD will have an @data-tei attribute
+ : referencing the TEI XML node which triggered the model. This is used to track elements between HTML and TEI. 
+ :)
+declare function pmu:process-odd($odd as document-node(), $output-root as xs:string,
+    $mode as xs:string, $relPath as xs:string, $config as element(modules)?, $trackIds as xs:boolean?) as map(*) {
     let $oddPath := ($odd/*/@source, document-uri(root($odd)))[1]
     let $name := replace($oddPath, "^.*?([^/\.]+)\.[^\.]+$", "$1")
     let $modulesDefault := pmu:parse-config-properties($mode, $name, $config, $pmu:MODULES?($mode))
@@ -131,7 +144,7 @@ declare function pmu:process-odd($odd as document-node(), $output-root as xs:str
         if (empty($module)) then
             error($pmu:ERR_UNKNOWN_MODE, "output mode " || $mode || " is unknown")
         else
-            let $generated := pm:parse($odd/*, pmu:fix-module-paths($module?modules), $module?output?*)
+            let $generated := pm:parse($odd/*, pmu:fix-module-paths($module?modules), $module?output?*, $trackIds)
             let $error := util:compile-query($generated?code, $output-root)
             return
                 if ($error/error) then

--- a/content/util.xql
+++ b/content/util.xql
@@ -117,6 +117,7 @@ declare function pmu:process($oddPath as xs:string, $xml as node()*, $output-roo
 
 declare function pmu:process-odd($odd as document-node(), $output-root as xs:string,
     $mode as xs:string, $relPath as xs:string, $config as element(modules)?) as map(*) {
+        pmu:process-odd($odd, $output-root, $mode, $relPath, $config, false())
 };
 
 (:~


### PR DESCRIPTION
Generates optional code to establish a mapping between the TEI source and the output HTML:

1. inject a post-processing step after every call to a processing model, which adds the eXist-internal node id of the TEI context node to the generated HTML (in attribute `data-tei`)
2. for every returned HTML element having a class `annotation-{type}` (where type denotes the type of the annotation), create a `data-annotation` attribute containing a JSON string with the serialized attributes of the original TEI element