### PR TITLE
fix($docx-copy): Remove closure for "xmldb:copy-resource"

### DIFF
--- a/content/docx.xql
+++ b/content/docx.xql
@@ -17,11 +17,9 @@ declare variable $docx:copy :=
         if (exists($copy4)) then
             $copy4
         else
-            let $copy5 := function-lookup(xs:QName("xmldb:copy-resource"), 4)
-            return
-                function ($source, $target, $resource) {
-                    $copy5($source, $resource, $target, $resource)
-                }
+            function ($source, $target, $resource) {
+                xmldb:copy-resource($source, $resource, $target, $resource)
+            }
 ;
 
 declare function docx:process($path as xs:string, $dataRoot as xs:string, $transform as function(*),

--- a/content/docx.xql
+++ b/content/docx.xql
@@ -18,7 +18,7 @@ declare variable $docx:copy :=
             $copy4
         else
             function ($source, $target, $resource) {
-                xmldb:copy-resource($source, $resource, $target, $resource)
+                function-lookup(xs:QName("xmldb:copy-resource"), 4)($source, $resource, $target, $resource)
             }
 ;
 


### PR DESCRIPTION
Since there is only ’xmldb:copy-resource#4` in exist 5.x, there is no
need to check for this function in a closure, as @line-o suggested.