### PR TITLE
Various fixes

### DIFF
--- a/content/ext-printcss.xql
+++ b/content/ext-printcss.xql
@@ -18,12 +18,6 @@ declare function pmf:note($config as map(*), $node as node(), $class as xs:strin
 };
 
 declare function pmf:alternate($config as map(*), $node as node(), $class as xs:string+, $content, $default, $alternate) {
-    <span class="{$class}">
-        <span class="default">
-        { html:apply-children($config, $node, $default) }
-        </span>
-        <span class="alternate">
-        { html:apply-children($config, $node, $alternate) }
-        </span>
-    </span>
+    <span class="{$class}">{$config?apply-children($config, $node, $default)}</span>,
+    pmf:note($config, $node, $class, $alternate, "footnote", ())
 };

--- a/test/ts-ext-printcss.xqm
+++ b/test/ts-ext-printcss.xqm
@@ -25,6 +25,6 @@ declare
   %test:assertTrue
 function tpc:alternate-nested-spans() as xs:boolean {
   let $res := pmf:alternate($tpc:CFG, <n/>, ("c"), (), 'D', 'A')
-  return name($res)='span' and $res/span[@class='default']='D' and $res/span[@class='alternate']='A'
+  return name($res[1])='span' and $res[2]/contains(@class, 'footnote')
 };
 

--- a/test/ts-markdown.xqm
+++ b/test/ts-markdown.xqm
@@ -11,6 +11,8 @@ declare variable $tmd:CFG :=
         "indent": "",
         "styles": map {
             "bold": map { "font-weight": "bold" },
+            "italic": map { "font-style": "italic" },
+            "del": map { "text-decoration": "line-through" },
             "gap:before": map { "content": "[…]" }
         }
     };
@@ -45,6 +47,27 @@ declare
     %test:assertEquals("**Hello**")
 function tmd:inline-bold() as xs:string {
     pmf:inline($tmd:CFG, <n/>, ("bold"), "Hello")
+    => string-join("")
+};
+
+declare
+    %test:assertEquals("**Hello world**")
+function tmd:inline-bold-with-leading-space() as xs:string {
+    pmf:finish($tmd:CFG, <root>{pmf:inline($tmd:CFG, <n/>, ("bold"), " Hello world")}</root>)
+    => string-join("")
+};
+
+declare
+    %test:assertEquals("_Hello world_")
+function tmd:inline-emphasis-with-trailing-space() as xs:string {
+    pmf:finish($tmd:CFG, <root>{pmf:inline($tmd:CFG, <n/>, ("italic"), "Hello world  ")}</root>)
+    => string-join("")
+};
+
+declare
+    %test:assertEquals("<del>Hello</del>")
+function tmd:inline-erased() as xs:string {
+    pmf:inline($tmd:CFG, <n/>, ("del"), "Hello")
     => string-join("")
 };
 

--- a/test/ts-markdown.xqm
+++ b/test/ts-markdown.xqm
@@ -56,7 +56,7 @@ function tmd:inline-css-content() as xs:string {
 };
 
 declare
-    %test:assertEquals("[^1][^1]: Hello&#10;")
+    %test:assertEquals("[^1]&#10;&#10;[^1]: Hello")
 function tmd:note() as xs:string {
     let $note := pmf:note($tmd:CFG, <n/>, ("note"), "Hello", "footnote", "1")
     return
@@ -64,11 +64,19 @@ function tmd:note() as xs:string {
 };
 
 declare
-    %test:assertEquals("Hello[^1]World.&#10;&#10;[^1]: Hello&#10;")
+    %test:assertEquals("Hello[^1] World.&#10;&#10;[^1]: Hello")
 function tmd:note-in-paragraph() as xs:string {
     let $note := pmf:note($tmd:CFG, <n/>, ("note"), "Hello", "footnote", "1")
     let $paragraph := pmf:paragraph($tmd:CFG, <n/>, ("paragraph"), 
         (text { "Hello" }, $note, text { " World." }))
     return
         pmf:finish($tmd:CFG, $paragraph)
+};
+
+declare
+    %test:assertEquals("[^a]&#10;&#10;[^a]: Hello")
+function tmd:note-custom-marker() as xs:string {
+    let $note := pmf:note($tmd:CFG, <n/>, ("note"), "Hello", "footnote", "a")
+    return
+        pmf:finish($tmd:CFG, $note)
 };


### PR DESCRIPTION
* allow desired output modes to be passed to `pmc:generate-pm-config`
* fix markdown output spacing and applying styles
* in printcss mode, output alternate as footnote