### PR TITLE
Make code compliant with the XQuery standard

### DIFF
--- a/content/xqgen.xql
+++ b/content/xqgen.xql
@@ -139,11 +139,11 @@ declare function xqgen:generate($nodes as node()*, $indent as xs:integer) {
     )
 };
 
-declare %private function xqgen:indent($amount as xs:int) {
+declare %private function xqgen:indent($amount as xs:integer) {
     substring($xqgen:SPACES, 1, $amount * 4)
 };
 
-declare %private function xqgen:indent($str as xs:string, $amount as xs:int) {
+declare %private function xqgen:indent($str as xs:string, $amount as xs:integer) {
     xqgen:indent($amount) ||
     replace($str, "\n", $xqgen:LF || xqgen:indent($amount))
 };


### PR DESCRIPTION
The previous code was not XQuery standards compliant. This updated code now will work on both eXist-db `6.x.x` and eXist-db `7.0.0-SNAPSHOT`.

As [tei-publisher-app](https://github.com/eeditiones/tei-publisher-app/blob/master/expath-pkg.xml#L6) depends on the much older TEI-Publisher-Lib 4.0.3 version, we would also like to see a backport of this to create a new 4.0.4 release version of tei-publisher-lib as well please. We would send a PR to help with that, but there is no 4.x.x branch provided for us to target.