### PR TITLE
fix(html): correctly process descendants in inline and note behaviours

### DIFF
--- a/content/html-functions.xql
+++ b/content/html-functions.xql
@@ -245,11 +245,11 @@ declare function pmf:note($config as map(*), $node as node(), $class as xs:strin
             if ($label) then (
                 <span class="{$class} margin-note-ref">{(pmf:add-language-attributes($node), $label)}</span>,
                 <span class="{$class} margin-note">
-                    <span class="n">{pmf:add-language-attributes($node), $label/string()} </span>{ $config?apply-children($config, $node, $content) }
+                    <span class="n">{pmf:add-language-attributes($node), $label/string()} </span>{ pmf:apply-children($config, $node, $content) }
                 </span>
             ) else
                 <span class="{$class} margin-note" id="margin_ref_{$id}">
-                { pmf:add-language-attributes($node), $config?apply-children($config, $node, $content) }
+                { pmf:add-language-attributes($node), pmf:apply-children($config, $node, $content) }
                 </span>
         default return
             let $nr :=
@@ -257,7 +257,7 @@ declare function pmf:note($config as map(*), $node as node(), $class as xs:strin
                     $label
                 else
                     counters:increment($pmf:NOTE_COUNTER_ID)
-            let $content := $config?apply-children($config, $node, $content)
+            let $content := pmf:apply-children($config, $node, $content)
             let $wcVersion :=
                 if ($config?parameters?webcomponents) then
                     try {
@@ -323,7 +323,7 @@ declare function pmf:inline($config as map(*), $node as node(), $class as xs:str
     <span class="{$class}">
     {
         pmf:add-language-attributes($node),
-        $config?apply-children($config, $node, $content)
+        pmf:apply-children($config, $node, $content)
     }
     </span>
 };


### PR DESCRIPTION
constructed content passed as `content` parameter to `inline` and `note` behaviours was outputted directly, without correctly descending processing